### PR TITLE
implement kml export function v0

### DIFF
--- a/functions/gnd-cloud-functions.js
+++ b/functions/gnd-cloud-functions.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 'use strict';
 
 const GndSpreadsheet = require('./gnd-spreadsheet');
@@ -27,10 +27,10 @@ class GndCloudFunctions {
   }
 
   getSheet_(projectId) {
-    return this.db_.fetchSheetsConfig(projectId).then(sheetConfig => 
-      sheetConfig 
-      && sheetConfig.sheetId 
-      && new GndSpreadsheet(this.auth_, sheetConfig.sheetId));
+    return this.db_.fetchSheetsConfig(projectId).then(sheetConfig =>
+      sheetConfig &&
+      sheetConfig.sheetId &&
+      new GndSpreadsheet(this.auth_, sheetConfig.sheetId));
   }
 
   exportKml(req, res) {
@@ -62,7 +62,8 @@ class GndCloudFunctions {
         }
         return Promise.all([
           project.ref.collection('features').get(),
-          project.ref.collection('records').get()]);
+          project.ref.collection('records').get()
+        ]);
       }
     ).then(
       results => {
@@ -77,7 +78,7 @@ class GndCloudFunctions {
             let featureTypeMap = data['projects'][projectId]['featureTypes'][featureTypeId];
             featureTypeMap['features'][feature.id] = {};
             featureTypeMap['features'][feature.id]['data'] = feature.data();
-            featureTypeMap['features'][feature.id]['records'] = {}; 
+            featureTypeMap['features'][feature.id]['records'] = {};
           }
         );
         const records = results[1];
@@ -156,22 +157,36 @@ class GndCloudFunctions {
   }
 
   onCreateRecord(change, context) {
-    const {projectId, featureId, recordId} = context.params;
+    const {
+      projectId,
+      featureId,
+      recordId
+    } = context.params;
     const record = change.data();
-    const {featureTypeId, formId} = record;
+    const {
+      featureTypeId,
+      formId
+    } = record;
     return this.getSheet_(projectId).then(sheet =>
-      sheet && sheet.getColumnIds().then(colIds => 
+      sheet && sheet.getColumnIds().then(colIds =>
         this.db_.fetchFeature(projectId, featureId).then(feature =>
           sheet.addRow(feature, featureId, recordId, record, colIds))));
   }
 
   onUpdateRecord(change, context) {
-    const {projectId, featureId, recordId} = context.params;
+    const {
+      projectId,
+      featureId,
+      recordId
+    } = context.params;
     const record = change.after.data();
-    const {featureTypeId, formId} = record;
+    const {
+      featureTypeId,
+      formId
+    } = record;
     return this.getSheet_(projectId).then(sheet =>
       sheet && sheet.getColumnIds().then(colIds =>
-        this.db_.fetchFeature(projectId, featureId).then(feature => 
+        this.db_.fetchFeature(projectId, featureId).then(feature =>
           sheet.updateRow(feature, featureId, recordId, record, colIds))));
   }
 }

--- a/functions/gnd-datastore.js
+++ b/functions/gnd-datastore.js
@@ -20,7 +20,7 @@
 class GndDatastore {
   constructor(db) {
     this.db_ = db;
-  }
+  }  
 
   fetch_(docRef) {
     return docRef.get().then(doc => doc.exists ? doc.data() : null);
@@ -30,16 +30,32 @@ class GndDatastore {
     return this.fetch_(this.db_.doc(path));    
   }
 
+  fetchCollection_(path) {
+    return this.db_.collection(path).get();
+  }
+
+  fetchProject(projectId) {
+    return this.db_.doc(`projects/${projectId}`).get();
+  }
+
   fetchRecord(projectId, featureId, recordId) {
     return this.fetchDoc_(`projects/${projectId}/features/${featureId}/records/${recordId}`);
   }
 
-  fetchForm(projectId, featureTypeId, formId) {
-    return this.fetchDoc_(`projects/${projectId}/featureTypes/${featureTypeId}/forms/${formId}`);
+  fetchRecords(projectId, featureId) {
+    return this.fetchCollection_(`projects/${projectId}/features/${featureId}/records`);
   }
 
   fetchFeature(projectId, featureId) {
     return this.fetchDoc_(`projects/${projectId}/features/${featureId}`);
+  }
+
+  fetchFeatures(projectId) {
+    return this.fetchCollection_(`projects/${projectId}/features`);
+  }
+
+  fetchForm(projectId, featureTypeId, formId) {
+    return this.fetchDoc_(`projects/${projectId}/featureTypes/${featureTypeId}/forms/${formId}`);
   }
 
   fetchSheetsConfig(projectId) {

--- a/functions/gnd-kml-writter.js
+++ b/functions/gnd-kml-writter.js
@@ -142,13 +142,13 @@ class GndKmlWritter {
           }
         );
       }
-      
+
       row += '<tr>'
       row +=
         '<th>' +
         GndKmlWritter.getFieldWithDesiredLanguage_(
-          questionLabels, desiredLanguage)
-        + '</th>';
+          questionLabels, desiredLanguage) +
+        '</th>';
       row += '<td>' + response + '</td>';
       row += '</tr>';
     }

--- a/functions/gnd-kml-writter.js
+++ b/functions/gnd-kml-writter.js
@@ -1,0 +1,140 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+class GndKmlWritter {
+
+  constructor(rawData, desiredLanguage) {
+    this.rawData_ = rawData;
+    this.desiredLanguage_ = desiredLanguage;
+  }
+
+  getTmpKmlFile() {
+    const kmlString = GndKmlWritter.buildKml_(this.rawData_, this.desiredLanguage_);
+
+    return new Promise((resolve, reject) => {
+      fs.mkdtemp(path.join(os.tmpdir(), 'gndExport-'), (err, folderPath) => {
+        if (err) reject(err);
+        return resolve(folderPath)
+      });
+    }).then(
+      folderPath => {
+        const filePath = folderPath + '/out.kml'
+        return new Promise((resolve, reject) => {
+          fs.writeFile(filePath, kmlString, (err) => {
+            if (err) reject(err);
+            console.log('KML data has been written to: ' + filePath);
+            return resolve(filePath);
+          });
+        });
+      }
+    );
+  }
+
+  static buildKml_(rawData, desiredLanguage) {
+    let kml = '';
+    kml += '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      '<kml xmlns="http://www.opengis.net/kml/2.2">\n';
+
+    for (var projectId in rawData['projects']) {
+      const project = rawData['projects'][projectId];
+      kml = GndKmlWritter.addProjectToKml_(kml, project, desiredLanguage);
+    }
+
+    kml += '</kml>\n';
+    return kml;
+  }
+
+  static addProjectToKml_(kml, project, desiredLanguage) {
+    kml += '<Document>\n';
+    kml +=
+      '<name>' +
+      GndKmlWritter.getFieldWithDesiredLanguage_(
+        project['data']['title'], [desiredLanguage]) +
+      '</name>\n';
+    kml +=
+      '<description>' +
+      GndKmlWritter.getFieldWithDesiredLanguage_(
+        project['data']['description'], [desiredLanguage]) +
+      '</description>\n';
+
+    for (var featureTypeId in project['featureTypes']) {
+      const features = project['featureTypes'][featureTypeId]['features'];
+      kml = GndKmlWritter.addFeatureTypeToKml_(kml, featureTypeId, features, desiredLanguage);
+    }
+
+    kml += '</Document>\n';
+    return kml;
+  }
+
+  // TODO: Add different styles for different featureTypeId
+  static addFeatureTypeToKml_(kml, featureTypeId, features, desiredLanguage) {
+    kml += '<Folder>\n';
+    kml += '<name>' + featureTypeId + '</name>\n';
+    for (var featureId in features) {
+      const feature = features[featureId];
+      kml = GndKmlWritter.addFeatureToKml_(kml, featureId, feature, desiredLanguage);
+    }
+
+    kml += '</Folder>\n';
+    return kml;
+  }
+
+  static addFeatureToKml_(kml, featureId, feature, desiredLanguage) {
+    kml += '<Placemark>\n';
+    kml += '<name>' + featureId + '</name>\n';
+
+    const records = feature['records'];
+    if (Object.keys(records).length > 0) {
+      kml = GndKmlWritter.addRecordsToKml_(kml, records, desiredLanguage);
+    }
+    const featureData = feature['data'];
+    kml = GndKmlWritter.addFeatureDataToKml_(kml, featureData);
+
+    kml += '</Placemark>\n';
+    return kml;
+  }
+
+  static addRecordsToKml_(kml, records, desiredLanguage) {
+    kml += '<description>';
+    kml += '<style>table, th, td {\n' +
+      'border: 1px solid black;\n' +
+      'border-collapse: collapse;\n' +
+      '}</style>\n';
+    kml += '<table>';
+    kml += '<tr><th>RecordId</th><th>Record</th></tr>';
+    for (var recordId in records) {
+      const record = records[recordId];
+      kml += '<tr>';
+      kml += '<td>' + recordId + '</td>';
+      kml += '<td><pre>' + JSON.stringify(record, null, 2) + '</pre></td>';
+      kml += '</tr>';
+    }
+    kml += '</table>';
+    kml += '</description>\n';
+    return kml;
+  }
+
+  static addFeatureDataToKml_(kml, featureData) {
+    const geoPoint = featureData['center'];
+    kml += '<Point>\n';
+    kml += '<coordinates>' + geoPoint.longitude + ',' + geoPoint.latitude + ',0</coordinates>\n';
+    kml += '</Point>\n';
+    return kml;
+  }
+
+  static getFieldWithDesiredLanguage_(data, desiredLanguage) {
+    const keys = new Set(Object.keys(data));
+    if (keys.size == 0) {
+      return '';
+    } else if (keys.has(desiredLanguage)) {
+      return data[desiredLanguage];
+    } else if (keys.has('_')) {
+      return data['_'];
+    } else {
+      return data[Object.keys(data)[0]];
+    }
+  }
+}
+
+module.exports = GndKmlWritter;

--- a/functions/index.js
+++ b/functions/index.js
@@ -31,6 +31,12 @@ const db = new GndDatastore(admin.firestore());
 const auth = new GndAuth();
 const gnd = new GndCloudFunctions(db, auth);
 
+exports.exportKml = functions.https.onRequest((req, res) =>
+	gnd.exportKml(req, res).catch(err => res.status(500).send(`${err}`)));
+
+exports.exportCsv = functions.https.onRequest((req, res) =>
+	gnd.exportCsv(req, res).catch(err => res.status(500).send(`${err}`)));
+
 // Test via shell:
 // updateColumns.get('/?project=R06MucQJSWvERdE7SiL1&featureType=aaaaaaaa&form=1234567')
 exports.updateColumns = functions.https.onRequest((req, res) => 


### PR DESCRIPTION
V0 implementation of exportKml() cloud function.

When triggered, the function will send a chain of queries to firestore to load the data of projects/features/records and store them in a js object. A separate KmlWritter class will take care of writing it into a kml file with correct format.

Tested locally and the out.kml can be imported by Google earth.