### PR TITLE
Add documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,3 @@
 title: Ground
-description: An open source, map-first data collection platform by volunteers @google.
+description: An open source, map-first data collection platform by global contributors and volunteers at [google](https://github.com/google).
 theme: jekyll-theme-cayman

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+title: Ground
+description: Ground documentation.
+theme: jekyll-theme-cayman

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,3 @@
 title: Ground
-description: Ground documentation.
+description: An open source, map-first data collection platform by volunteers @google.
 theme: jekyll-theme-cayman

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,3 @@
 title: Ground
-description: An open source, map-first data collection platform by global contributors and volunteers at [google](https://github.com/google).
+description: An open source, map-first data collection platform by global contributors and volunteers at Google.
 theme: jekyll-theme-cayman

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ researchers, NGOs, and other interest groups to collect data that matters.
 on a best-effort basis. If you would like to contribute to Ground development,
 see the [Contribute](#contribute) section. If you have questions or ideas about
 Ground that you'd like to share, post them to the
-https://groups.google.com/forum/#!forum/ground-discuss discussion group.
+[ground-discuss](https://groups.google.com/forum/#!forum/ground-discuss) discussion group.
 
 <!--Partner Reel-->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,6 @@
 title: "Ground"
 layout: default
 ---
-# Ground
 
 Ground is an open source, map-first data collection platform that enables users
 to collect, map, and share data, even when a stable internet connection isn't
@@ -14,14 +13,14 @@ researchers, NGOs, and other interest groups to collect data that matters.
 on a best-effort basis. If you would like to contribute to Ground development,
 see the [Contribute](#contribute) section. If you have questions or ideas about
 Ground that you'd like to share, post them to the
-https://groups.google.com/forum/#!forum/ground-discuss discussion group.
+[ground-discuss](https://groups.google.com/forum/#!forum/ground-discuss) discussion group.
 
 <!--Partner Reel-->
 
-## Features
+# Features
 
-*   **Flexible Data Collection**: **Raster basemaps**, **photo, audio, and video
-    attachments**, **custom forms and data validation**, and other features,
+*   **Flexible Data Collection**: Raster basemaps, photo, audio, and video
+    attachments, custom forms and data validation, and other features,
     make Ground a great tool for collecting geospatial data on a wide range of
     domains. You can tune Ground to meet your needs, whether you're tracking
     malaria outbreaks or mapping animal habitats.
@@ -30,13 +29,13 @@ https://groups.google.com/forum/#!forum/ground-discuss discussion group.
     scientists, and small to large enterprises to manage and own the entire
     process, from setting up and running a project, to visualizing and analyzing
     results. Collaboration features make small and large scale
-    **crowd-sourcing** possible out of the box. This allows users to apply local
+    crowd-sourcing possible out of the box. This allows users to apply local
     knowledge at scale to produce otherwise inaccessible insights.
 
 *   **Offline First**: Mobility is crucial when collecting or verifying data in
-    remote areas. Ground's **offline mobile data collection** and **offline
-    raster basemaps** give users uninterrupted access to important data wherever
-    they may be. Intelligent **background data sync** automatically uploads new
+    remote areas. Ground's offline mobile data collection and offline
+    raster basemaps give users uninterrupted access to important data wherever
+    they may be. Intelligent background data sync automatically uploads new
     data when an internet connection is available.
 
 *   **Remeasurement**: Ground's unique data collection model not only allows
@@ -45,7 +44,7 @@ https://groups.google.com/forum/#!forum/ground-discuss discussion group.
     community food and water resources, algae levels, and other dynamic data
     points.
 
-## Use Cases
+# Use Cases
 
 It's the Ground team's mission to make Ground adaptable to a broad range of
 humanitarian, data-intensive, and geospatial use cases, such as:
@@ -67,7 +66,7 @@ humanitarian, data-intensive, and geospatial use cases, such as:
 
 *   **Civic Engagement**: Ground can enhance civic participation by equipping
     policy makers, community groups, and institutions with the data they need to
-    assess political sentiment and enact change. Civic organizations can use
+    assess public sentiment and enact change. Civic organizations can use
     Ground to facilitate civic engagement, poll citizenry, and analyze the
     political landscape.
 
@@ -78,14 +77,14 @@ humanitarian, data-intensive, and geospatial use cases, such as:
     Communities can use Ground to assist their collaborations with community
     knowledge holders on field trips and during interviews.
 
-## Get Involved
+# Get Involved
 
 Ground is open source and relies on contributions from the open source community
 to sustain its development. The sections below describe ways you can help Ground
 become the go-to tool for high impact geospatial data collection projects around
 the world.
 
-### Contribute
+## Contribute
 
 If you'd like to contribute to the development of Ground source code, check out
 one of the currently maintained Ground source repositories:
@@ -93,21 +92,21 @@ one of the currently maintained Ground source repositories:
 *Important:* Be sure to read each repository's contribution guidelines before
 contributing!
 
-*   https://github.com/google/gnd-cloud: Contains source code for Ground cloud
+*   <https://github.com/google/gnd-cloud>: Contains source code for Ground cloud
     components.
 
-*   https://github.com/google/gnd-android: Contains source code for the Ground
+*   <https://github.com/google/gnd-android>: Contains source code for the Ground
     Android application.
 
-### Join the Discussion
+## Join the Discussion
 
 Join official Ground discussion groups to get updates on new features, get in
 touch with other Ground users, and add your voice to the conversation:
 
-*   https://groups.google.com/forum/#!forum/ground-discuss: General discussions
+*   <https://groups.google.com/forum/#!forum/ground-discuss>: General discussions
     about Ground are held in this discussion group. Join to explore ideas with
     others, ask questions, or engage with the Ground community.
 
-*   https://groups.google.com/forum/#!forum/ground-announcements: Project wide
+*   <https://groups.google.com/forum/#!forum/ground-announcements>: Project wide
     announcements happen in this discussion group. Join this group to stay up to
     date on major feature updates and other important changes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,8 @@ one of the currently maintained Ground source repositories:
 contributing!
 
 *   <https://github.com/google/gnd-cloud>: Contains source code for Ground cloud
-    components.
+    components, including the Web Console and Firebase Cloud Functions and
+    database config.
 
 *   <https://github.com/google/gnd-android>: Contains source code for the Ground
     Android application.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,21 +19,21 @@ Ground that you'd like to share, post them to the
 
 # Features
 
-*   **Flexible Data Collection**: **Raster basemaps**, **photo, audio, and video
-    attachments**, **custom forms and data validation**, and other features,
+*   **Flexible Data Collection**: Raster basemaps, photo, audio, and video
+    attachments, custom forms and data validation, and other features,
     make Ground a great tool for collecting geospatial data on a wide range of
     domains. You can tune Ground to meet your needs, whether you're tracking
     malaria outbreaks or mapping animal habitats.
 
 *   **Community Engagement**: Use Ground to foster interest, trust, and
-    participation with local and global communities. **Crowd-sourcing** features
+    participation with local and global communities. Crowd-sourcing features
     provide a means leveraging local knowledge at a large scale to produce
     otherwise inaccessible insights.
 
 *   **Offline First**: Mobility is crucial when collecting or verifying data in
-    remote areas. Ground's **offline mobile data collection** and **offline
-    raster basemaps** give users uninterrupted access to important data wherever
-    they may be. Intelligent **background data sync** automatically uploads new
+    remote areas. Ground's offline mobile data collection and offline
+    raster basemaps give users uninterrupted access to important data wherever
+    they may be. Intelligent background data sync automatically uploads new
     data when an internet connection is available.
 
 *   **Remeasurement**: Ground's unique data collection model doesn't only allow

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 title: "Ground"
 layout: default
 ---
+# Ground
 
 Ground is an open source, map-first data collection platform that enables users
 to collect, map, and share data, even when a stable internet connection isn't
@@ -13,35 +14,38 @@ researchers, NGOs, and other interest groups to collect data that matters.
 on a best-effort basis. If you would like to contribute to Ground development,
 see the [Contribute](#contribute) section. If you have questions or ideas about
 Ground that you'd like to share, post them to the
-[ground-discuss](https://groups.google.com/forum/#!forum/ground-discuss) discussion group.
+https://groups.google.com/forum/#!forum/ground-discuss discussion group.
 
 <!--Partner Reel-->
 
-# Features
+## Features
 
-*   **Flexible Data Collection**: Raster basemaps, photo, audio, and video
-    attachments, custom forms and data validation, and other features,
+*   **Flexible Data Collection**: **Raster basemaps**, **photo, audio, and video
+    attachments**, **custom forms and data validation**, and other features,
     make Ground a great tool for collecting geospatial data on a wide range of
     domains. You can tune Ground to meet your needs, whether you're tracking
     malaria outbreaks or mapping animal habitats.
 
-*   **Community Engagement**: Use Ground to foster interest, trust, and
-    participation with local and global communities. Crowd-sourcing features
-    provide a means leveraging local knowledge at a large scale to produce
-    otherwise inaccessible insights.
+*   **Community Engagement**: Ground allows local communities, citizen
+    scientists, and small to large enterprises to manage and own the entire
+    process, from setting up and running a project, to visualizing and analyzing
+    results. Collaboration features make small and large scale
+    **crowd-sourcing** possible out of the box. This allows users to apply local
+    knowledge at scale to produce otherwise inaccessible insights.
 
 *   **Offline First**: Mobility is crucial when collecting or verifying data in
-    remote areas. Ground's offline mobile data collection and offline
-    raster basemaps give users uninterrupted access to important data wherever
-    they may be. Intelligent background data sync automatically uploads new
+    remote areas. Ground's **offline mobile data collection** and **offline
+    raster basemaps** give users uninterrupted access to important data wherever
+    they may be. Intelligent **background data sync** automatically uploads new
     data when an internet connection is available.
 
-*   **Remeasurement**: Ground's unique data collection model doesn't only allow
+*   **Remeasurement**: Ground's unique data collection model not only allows
     collection of data in space, but also allows remeasurement of observations
     over time and/or by multiple users. Map and monitor glacial movements,
-    community growth, algae levels, and other dynamic data points.
+    community food and water resources, algae levels, and other dynamic data
+    points.
 
-# Use Cases
+## Use Cases
 
 It's the Ground team's mission to make Ground adaptable to a broad range of
 humanitarian, data-intensive, and geospatial use cases, such as:
@@ -63,25 +67,25 @@ humanitarian, data-intensive, and geospatial use cases, such as:
 
 *   **Civic Engagement**: Ground can enhance civic participation by equipping
     policy makers, community groups, and institutions with the data they need to
-    assess public sentiment and enact change. Civic organizations can use
+    assess political sentiment and enact change. Civic organizations can use
     Ground to facilitate civic engagement, poll citizenry, and analyze the
     political landscape.
 
 *   **Traditional Knowledge Preservation** Using Ground, indigenous communities
     can record place-based traditional knowledge, skills, and practices. Ground
     empowers stewards of tradition to incorporate sites of cultural and natural
-    signifigance into land mangement and community development decisions.
-    Researchers can use Ground to augment their collaborations with community
-    knowledge experts on field trips and during interviews.
+    significance into land management and community development decisions.
+    Communities can use Ground to assist their collaborations with community
+    knowledge holders on field trips and during interviews.
 
-# Get Involved
+## Get Involved
 
 Ground is open source and relies on contributions from the open source community
 to sustain its development. The sections below describe ways you can help Ground
 become the go-to tool for high impact geospatial data collection projects around
 the world.
 
-## Contribute
+### Contribute
 
 If you'd like to contribute to the development of Ground source code, check out
 one of the currently maintained Ground source repositories:
@@ -89,22 +93,21 @@ one of the currently maintained Ground source repositories:
 *Important:* Be sure to read each repository's contribution guidelines before
 contributing!
 
-*   <https://github.com/google/gnd-cloud>: Contains source code for Ground cloud
+*   https://github.com/google/gnd-cloud: Contains source code for Ground cloud
     components.
 
-*   <https://github.com/google/gnd-android>: Contains source code for the Ground
+*   https://github.com/google/gnd-android: Contains source code for the Ground
     Android application.
 
-## Join the Discussion
+### Join the Discussion
 
 Join official Ground discussion groups to get updates on new features, get in
 touch with other Ground users, and add your voice to the conversation:
 
-*   <https://groups.google.com/forum/#!forum/ground-discuss>: General discussions
+*   https://groups.google.com/forum/#!forum/ground-discuss: General discussions
     about Ground are held in this discussion group. Join to explore ideas with
     others, ask questions, or engage with the Ground community.
 
-*   <https://groups.google.com/forum/#!forum/ground-announcements>: Project wide
+*   https://groups.google.com/forum/#!forum/ground-announcements: Project wide
     announcements happen in this discussion group. Join this group to stay up to
     date on major feature updates and other important changes.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,110 @@
+---
+title: "Ground"
+layout: default
+---
+
+Ground is an open source, map-first data collection platform that enables users
+to collect, map, and share data, even when a stable internet connection isn't
+guaranteed. The Ground team, made up of volunteers at Google and contributors
+from the open source community, aspires to empower local communities,
+researchers, NGOs, and other interest groups to collect data that matters.
+
+**Note:** Ground is not an officially supported Google product, and is developed
+on a best-effort basis. If you would like to contribute to Ground development,
+see the [Contribute](#contribute) section. If you have questions or ideas about
+Ground that you'd like to share, post them to the
+https://groups.google.com/forum/#!forum/ground-discuss discussion group.
+
+<!--Partner Reel-->
+
+# Features
+
+*   **Flexible Data Collection**: **Raster basemaps**, **photo, audio, and video
+    attachments**, **custom forms and data validation**, and other features,
+    make Ground a great tool for collecting geospatial data on a wide range of
+    domains. You can tune Ground to meet your needs, whether you're tracking
+    malaria outbreaks or mapping animal habitats.
+
+*   **Community Engagement**: Use Ground to foster interest, trust, and
+    participation with local and global communities. **Crowd-sourcing** features
+    provide a means leveraging local knowledge at a large scale to produce
+    otherwise inaccessible insights.
+
+*   **Offline First**: Mobility is crucial when collecting or verifying data in
+    remote areas. Ground's **offline mobile data collection** and **offline
+    raster basemaps** give users uninterrupted access to important data wherever
+    they may be. Intelligent **background data sync** automatically uploads new
+    data when an internet connection is available.
+
+*   **Remeasurement**: Ground's unique data collection model doesn't only allow
+    collection of data in space, but also allows remeasurement of observations
+    over time and/or by multiple users. Map and monitor glacial movements,
+    community growth, algae levels, and other dynamic data points.
+
+# Use Cases
+
+It's the Ground team's mission to make Ground adaptable to a broad range of
+humanitarian, data-intensive, and geospatial use cases, such as:
+
+*   **Environmental Conservation**: Environmental organizations and
+    conservationists can use Ground to capture ecological data, map migration
+    routes or habitats, and discover and mitigate the effects of environmental
+    change.
+
+*   **Resource Management**: Using Ground, communities can manage resources in
+    conditions of scarcity, such as droughts or food shortages. Individuals can
+    report on the status of shared infrastructure, and relief and recovery teams
+    can assess and determine the best distribution of available aid.
+
+*   **Social Analysis**: Sociologists and students can use Ground to collect and
+    analyze population data, community growth, and other social factors.
+    Researchers can use Ground to encourage the direct participation of
+    communities in the research process.
+
+*   **Civic Engagement**: Ground can enhance civic participation by equipping
+    policy makers, community groups, and institutions with the data they need to
+    assess public sentiment and enact change. Civic organizations can use
+    Ground to facilitate civic engagement, poll citizenry, and analyze the
+    political landscape.
+
+*   **Traditional Knowledge Preservation** Using Ground, indigenous communities
+    can record place-based traditional knowledge, skills, and practices. Ground
+    empowers stewards of tradition to incorporate sites of cultural and natural
+    signifigance into land mangement and community development decisions.
+    Researchers can use Ground to augment their collaborations with community
+    knowledge experts on field trips and during interviews.
+
+# Get Involved
+
+Ground is open source and relies on contributions from the open source community
+to sustain its development. The sections below describe ways you can help Ground
+become the go-to tool for high impact geospatial data collection projects around
+the world.
+
+## Contribute
+
+If you'd like to contribute to the development of Ground source code, check out
+one of the currently maintained Ground source repositories:
+
+*Important:* Be sure to read each repository's contribution guidelines before
+contributing!
+
+*   https://github.com/google/gnd-cloud: Contains source code for Ground cloud
+    components.
+
+*   https://github.com/google/gnd-android: Contains source code for the Ground
+    Android application.
+
+## Join the Discussion
+
+Join official Ground discussion groups to get updates on new features, get in
+touch with other Ground users, and add your voice to the conversation:
+
+*   https://groups.google.com/forum/#!forum/ground-discuss: General discussions
+    about Ground are held in this discussion group. Join to explore ideas with
+    others, ask questions, or engage with the Ground community.
+
+*   https://groups.google.com/forum/#!forum/ground-announcements: Project wide
+    announcements happen in this discussion group. Join this group to stay up to
+    date on major feature updates and other important changes.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,10 +89,10 @@ one of the currently maintained Ground source repositories:
 *Important:* Be sure to read each repository's contribution guidelines before
 contributing!
 
-*   https://github.com/google/gnd-cloud: Contains source code for Ground cloud
+*   <https://github.com/google/gnd-cloud>: Contains source code for Ground cloud
     components.
 
-*   https://github.com/google/gnd-android: Contains source code for the Ground
+*   <https://github.com/google/gnd-android>: Contains source code for the Ground
     Android application.
 
 ## Join the Discussion
@@ -100,11 +100,11 @@ contributing!
 Join official Ground discussion groups to get updates on new features, get in
 touch with other Ground users, and add your voice to the conversation:
 
-*   https://groups.google.com/forum/#!forum/ground-discuss: General discussions
+*   <https://groups.google.com/forum/#!forum/ground-discuss>: General discussions
     about Ground are held in this discussion group. Join to explore ideas with
     others, ask questions, or engage with the Ground community.
 
-*   https://groups.google.com/forum/#!forum/ground-announcements: Project wide
+*   <https://groups.google.com/forum/#!forum/ground-announcements>: Project wide
     announcements happen in this discussion group. Join this group to stay up to
     date on major feature updates and other important changes.
 


### PR DESCRIPTION
This change adds a docs folder, jekyll config file, and index page for the Ground documentation site. 

Note that some repository settings need to be configured before github will serve the docs folder from github pages: https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/

You can view preview output here: olsen.works/gnd-cloud/ —this is the layout the site will use as soon as the repository is configured to serve pages from the docs folder. If the cayman theme isn't doing it for you, there are some other native github pages themes here: https://pages.github.com/themes/. We can also add custom css and layouts if needed.
